### PR TITLE
Unngå overallokering av CPU og minne

### DIFF
--- a/naiserator-prod.yaml
+++ b/naiserator-prod.yaml
@@ -39,8 +39,8 @@ spec:
       cpu: 2000m
       memory: 2Gi
     requests:
-      cpu: 2000m
-      memory: 2Gi
+      cpu: 200m
+      memory: 512Mi
   azure:
     application:
       enabled: true


### PR DESCRIPTION
Ser at appen allokerer unødvendig mye ressurser. Nodene har pt. veldig mye ledig kapasitet, så dette trengs ikke. Ved å justere requests slik som her påvirkes ikke når appen blir OOMKilled, dette styres av limit. Dette er bare hva som blir reservert, og slik situasjonen er nå er nodene på ca 5% utnyttelse.
Det jobbes med en bedre måte å angi og styre dette, da dette ikke er veldig lett å verken se pr. app, forstå hvordan virker 100% eller forholde seg til over tid.

Her er et par dashboards som er laget foreløpig som gir litt oversikt:

app: https://metabase.intern.nav.no/dashboard/3?cluster=prod-gcp&application=sykmeldinger-backend-kafka&periode=past7days~
team: https://metabase.intern.nav.no/dashboard/2?cluster=prod-gcp&team=teamsykmelding&periode=past7days~
cluster: https://metabase.intern.nav.no/dashboard/1-kubernetes-ressursbruk-cluster?cluster=prod-gcp&periode=past7days~